### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+We love pull requests from everyone! We want to keep it as easy as possible to
+contribute changes. There are a few guidelines that we need contributors to
+follow so that we can keep on top of things.
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* Submit a GitHub issue, assuming one does not already exist.
+  * Clearly describe the issue including steps to reproduce when it is a bug.
+  * Make sure you fill in the earliest version that you know has the issue.
+* Fork the repository on GitHub.
+
+## Making Changes
+
+* Create a topic branch from the master branch.
+* Make and commit your changes in the topic branch.
+
+Commited code must pass:
+
+* [gofmt](https://golang.org/cmd/gofmt)
+* [go test](https://golang.org/cmd/go/#hdr-Test_packages)
+
+## Submitting Changes
+
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a pull request to the repository in the microscaling organization.
+* Update your GitHub issue with a link to the pull request.
+* At this point you're waiting on us. We like to at least comment on pull requests
+within three business days (and, typically, one business day). We may suggest
+some changes or improvements or alternatives.
+* After feedback has been given we expect responses within two weeks. After two
+  weeks we may close the pull request if it isn't showing any activity.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Our Microscaling Engine provides automation, resilience and efficiency for microservice architectures. You can use our [Microscaling-in-a-Box](https://app.microscaling.com) site to
 experiment with microscaling. Or visit [microscaling.com](https://microscaling.com) to find out more about our product and Microscaling Systems.
 
-[![Build Status](https://api.travis-ci.org/microscaling/microcaling.svg)](https://travis-ci.org/microscaling/microscaling) Go 1.4 1.5 1.6
+[![Build Status](https://travis-ci.org/microscaling/microscaling.svg?branch=master)](https://travis-ci.org/microscaling/microscaling) Go 1.4 1.5 1.6
 [![](https://badge.imagelayers.io/microscaling/microscaling:latest.svg)](https://imagelayers.io/?images=microscaling/microscaling:latest 'Get your own badge on imagelayers.io')
 
 Microscaling Engine is under development, so we're not making any promises about forward compatibility, and we wouldn't advise running it on production machines yet. But if you're keen to get it into production we'd love to hear from you.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you want to build and run your own version locally:
 
 Microscaling Engine is licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/microscaling/microscaling/blob/master/LICENSE) for the full license text.
 
+## Contributing
+
+We'd love to get contributions from you! Please see [CONTRIBUTING.md](https://github.com/microscaling/microscaling/blob/master/CONTRIBUTING.md) for more details.
+
 ## Contact Us
 
 We'd love to hear from you at [hello@microscaling.com](mailto:hello@microscaling.com) or on Twitter at [@microscaling](http://twitter.com/microscaling). 


### PR DESCRIPTION
Contribution guidelines based on the examples from Puppet and Thoughtbot cited by [GitHub](https://github.com/blog/1184-contributing-guidelines). No Code of Conduct yet but we may want to add one later.