### PR TITLE
We'll want to be able to send outgoing metrics to different places

### DIFF
--- a/engine/interface.go
+++ b/engine/interface.go
@@ -1,3 +1,4 @@
+// Package engine defines engines that calculate (or retrieve) what the demand for each task is
 package engine
 
 import (

--- a/metric/interface.go
+++ b/metric/interface.go
@@ -1,3 +1,4 @@
+// Package metric defines things that we measure to determine how well a task is performing
 package metric
 
 import (

--- a/monitor/interface.go
+++ b/monitor/interface.go
@@ -1,0 +1,16 @@
+// Package monitor defines monitors, where we send updates about tasks and performance
+package monitor
+
+import (
+	"github.com/op/go-logging"
+
+	"github.com/microscaling/microscaling/demand"
+)
+
+// Monitor defines the interface for monitors, which receive information about microscaling on a regular basis
+type Monitor interface {
+	// SendMetrics sends information about the current state of tasks to the monitor
+	SendMetrics(tasks *demand.Tasks) (err error)
+}
+
+var log = logging.MustGetLogger("mssmonitor")

--- a/monitor/server.go
+++ b/monitor/server.go
@@ -1,0 +1,28 @@
+package monitor
+
+import (
+	"golang.org/x/net/websocket"
+
+	"github.com/microscaling/microscaling/api"
+	"github.com/microscaling/microscaling/demand"
+)
+
+// ServerMonitor receives metrics over the Microscaling API on the websocket
+type ServerMonitor struct {
+	ws     *websocket.Conn
+	userID string
+}
+
+// NewServerMonitor returns a new monitor that uses the Microscaling API to send metrics about running tasks and demand
+func NewServerMonitor(ws *websocket.Conn, userID string) *ServerMonitor {
+	return &ServerMonitor{
+		ws:     ws,
+		userID: userID,
+	}
+}
+
+// SendMetrics uses the Microscaling API to send metrics about all the running tasks and demand
+func (m *ServerMonitor) SendMetrics(tasks *demand.Tasks) (err error) {
+	err = api.SendMetrics(m.ws, m.userID, tasks)
+	return
+}

--- a/monitor/server_test.go
+++ b/monitor/server_test.go
@@ -1,0 +1,42 @@
+package monitor
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/microscaling/microscaling/demand"
+	"github.com/microscaling/microscaling/utils"
+	"golang.org/x/net/websocket"
+)
+
+func testServerMetrics(ws *websocket.Conn) {
+	// Contents are tested elsewhere, this just checks we can read something off the socket
+	var b []byte
+	b = make([]byte, 1000)
+	ws.Read(b)
+}
+
+func TestServerMonitor(t *testing.T) {
+	var tasks demand.Tasks
+	tasks.Tasks = make([]*demand.Task, 2)
+
+	tasks.Tasks[0] = &demand.Task{Name: "priority1", Demand: 8, Requested: 3, Running: 4}
+	tasks.Tasks[1] = &demand.Task{Name: "priority2", Demand: 2, Requested: 7, Running: 5}
+
+	server := httptest.NewServer(websocket.Handler(testServerMetrics))
+	serverAddr := server.Listener.Addr().String()
+
+	ws, err := utils.InitWebSocket(serverAddr)
+	if err != nil {
+		t.Fatal("dialing", err)
+	}
+
+	s := NewServerMonitor(ws, "hello")
+	if s.userID != "hello" {
+		t.Fatal("Didn't set userID")
+	}
+	s.SendMetrics(&tasks)
+
+	ws.Close()
+	server.Close()
+}


### PR DESCRIPTION
I've called these places "monitors" and I think there could be more than one simultaneously (e.g. write to influxDB as well as sending to the server