### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ build: docker_build output
 # Build and push Docker image
 release: docker_build docker_push output
 
-# Image can be overidden with an env var.
+# Image and binary can be overidden with env vars.
 DOCKER_IMAGE ?= microscaling/microscaling
+BINARY ?= microscaling
 
 # Get the latest commit.
 GIT_COMMIT = $(strip $(shell git rev-parse --short HEAD))
@@ -46,16 +47,19 @@ else
 DOCKER_TAG = $(CODE_VERSION)-$(GIT_COMMIT)$(DOCKER_TAG_SUFFIX)
 endif
 
+SOURCES := $(shell find . -name '*.go')
+
 test:
 	go test -v ./...
 
 get-deps:
 	go get -t -v ./...
 
-docker_build:
+$(BINARY): $(SOURCES)
 	# Compile for Linux
-	GOOS=linux go build -o microscaling
+	GOOS=linux go build -o $(BINARY)	
 
+docker_build: $(BINARY)
 	# Build Docker image
 	docker build \
   --build-arg VCS_URL=`git config --get remote.origin.url` \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(error You need to create a VERSION file to build a release)
 endif
 
 # See what commit is tagged to match the version
-VERSION_COMMIT = $(strip $(shell git show-ref --tags $(CODE_VERSION) -s --abbrev=7))
+VERSION_COMMIT = $(strip $(shell git rev-list $(CODE_VERSION) -n 1 | cut -c1-7))
 ifneq ($(VERSION_COMMIT), $(GIT_COMMIT))
 $(error echo You are trying to push a build based on commit $(GIT_COMMIT) but the tagged release version is $(VERSION_COMMIT))
 endif


### PR DESCRIPTION
Separate target for the binary, so you can rebuild the Docker file without a go build if appropriate