### PR TITLE
Fix problem starting containers with Docker 1.12

### DIFF
--- a/scheduler/docker/docker.go
+++ b/scheduler/docker/docker.go
@@ -95,11 +95,10 @@ func (c *DockerScheduler) startTask(task *demand.Task) {
 			Labels:       labels,
 			Env:          task.Env,
 		},
-	}
-
-	hostConfig := docker.HostConfig{
-		PublishAllPorts: task.PublishAllPorts,
-		NetworkMode:     task.NetworkMode,
+		HostConfig: &docker.HostConfig{
+			PublishAllPorts: task.PublishAllPorts,
+			NetworkMode:     task.NetworkMode,
+		},
 	}
 
 	go func() {
@@ -122,8 +121,8 @@ func (c *DockerScheduler) startTask(task *demand.Task) {
 		c.Unlock()
 		log.Debugf("[created] task %s ID %s", task.Name, containerID)
 
-		// Start it
-		err = c.client.StartContainer(containerID, &hostConfig)
+		// Start it but passing nil for the HostConfig as this option was removed in Docker 1.12.
+		err = c.client.StartContainer(containerID, nil)
 		if err != nil {
 			log.Errorf("Couldn't start container ID %s for task %s: %v", containerID, task.Name, err)
 			return


### PR DESCRIPTION
When starting containers pass the HostConfig with the ContainerCreateOptions rather than on the StartContainer API call. The HostConfig parameter on StartContainer was deprecated in Docker 1.10 and removed in 1.12.